### PR TITLE
Enabling ``wire_names``

### DIFF
--- a/src/qiboml/interfaces/keras.py
+++ b/src/qiboml/interfaces/keras.py
@@ -51,7 +51,7 @@ class QuantumModel(keras.Model):  # pylint: disable=no-member
 
         if isinstance(self.circuit_structure, Circuit):
             self.circuit_structure = [self.circuit_structure]
-        utils._uniform_circuit_structure_density_matrix(self.circuit_structure)
+        utils._uniform_circuit_structure(self.circuit_structure)
 
         params = utils.get_params_from_circuit_structure(self.circuit_structure)
         params = keras.ops.cast(

--- a/src/qiboml/interfaces/pytorch.py
+++ b/src/qiboml/interfaces/pytorch.py
@@ -48,7 +48,7 @@ class QuantumModel(torch.nn.Module):
 
         if isinstance(self.circuit_structure, Circuit):
             self.circuit_structure = [self.circuit_structure]
-        utils._uniform_circuit_structure_density_matrix(self.circuit_structure)
+        utils._uniform_circuit_structure(self.circuit_structure)
 
         params = utils.get_params_from_circuit_structure(self.circuit_structure)
         params = torch.as_tensor(self.backend.to_numpy(x=params)).ravel()
@@ -183,7 +183,9 @@ class QuantumModelAutoGrad(torch.autograd.Function):
         # Build the temporary circuit from the circuit structure.
         ctx.differentiable_encodings = True
         circuit = Circuit(
-            decoding.nqubits, density_matrix=circuit_structure[0].density_matrix
+            decoding.nqubits,
+            density_matrix=circuit_structure[0].density_matrix,
+            wire_names=circuit_structure[0].wire_names,
         )
         for circ in circuit_structure:
             if isinstance(circ, QuantumEncoding):

--- a/src/qiboml/models/ansatze.py
+++ b/src/qiboml/models/ansatze.py
@@ -1,20 +1,21 @@
 import random
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 from qibo import Circuit, gates
 
+from qiboml.models.utils import _get_wire_names_and_qubits
+
 
 def HardwareEfficient(
     nqubits: int,
-    qubits: list[int] = None,
+    qubits: Optional[Union[tuple[int], tuple["str"]]] = None,
     nlayers: int = 1,
     density_matrix: Optional[bool] = False,
 ) -> Circuit:
-    if qubits is None:
-        qubits = list(range(nqubits))
 
-    circuit = Circuit(nqubits, density_matrix=density_matrix)
+    qubits, wire_names = _get_wire_names_and_qubits(nqubits, qubits)
+    circuit = Circuit(nqubits, density_matrix=density_matrix, wire_names=wire_names)
 
     for _ in range(nlayers):
         for q in qubits:

--- a/src/qiboml/models/decoding.py
+++ b/src/qiboml/models/decoding.py
@@ -54,6 +54,9 @@ class QuantumDecoding:
         """
         self._circuit.density_matrix = x.density_matrix
         self._circuit.init_kwargs["density_matrix"] = x.density_matrix
+        self._circuit.wire_names = x.wire_names
+        self._circuit.init_kwargs["wire_names"] = x.wire_names
+
         if self.transpiler is not None:
             x, _ = self.transpiler(x)
         return self.backend.execute_circuit(x + self._circuit, nshots=self.nshots)

--- a/src/qiboml/models/encoding.py
+++ b/src/qiboml/models/encoding.py
@@ -2,13 +2,14 @@ import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 from qibo import Circuit, gates
 from qibo.config import raise_error
 
 from qiboml import ndarray
+from qiboml.models.utils import _get_wire_names_and_qubits
 
 
 @dataclass(eq=False)
@@ -23,7 +24,7 @@ class QuantumEncoding(ABC):
     """
 
     nqubits: int
-    qubits: Optional[tuple[int]] = None
+    qubits: Optional[Union[tuple[int], tuple["str"]]] = None
     density_matrix: Optional[bool] = False
     _circuit: Circuit = None
 
@@ -31,10 +32,12 @@ class QuantumEncoding(ABC):
         self,
     ):
         """Ancillary post initialization for the dataclass object."""
-        self.qubits = (
-            tuple(range(self.nqubits)) if self.qubits is None else tuple(self.qubits)
+        self.qubits, self.wire_names = _get_wire_names_and_qubits(
+            self.nqubits, self.qubits
         )
-        self._circuit = Circuit(self.nqubits, density_matrix=self.density_matrix)
+        self._circuit = Circuit(
+            self.nqubits, density_matrix=self.density_matrix, wire_names=self.wire_names
+        )
 
     @cached_property
     def _data_to_gate(self):

--- a/src/qiboml/models/encoding.py
+++ b/src/qiboml/models/encoding.py
@@ -19,7 +19,7 @@ class QuantumEncoding(ABC):
 
     Args:
         nqubits (int): total number of qubits.
-        qubits (tuple[int], optional): set of qubits it acts on, by default ``range(nqubits)``.
+        qubits (tuple[int] | tuple[str], optional): set of qubits it acts on, by default ``range(nqubits)``. Optionally, the name of the wires to run on can be passed through this argument. This is mainly useful when executing on hardware to select which qubits to make use of.
         density_matrix (bool, optional): whether to build the circuit with ``density_matrix=True``, mostly useful for noisy simulations. ``density_matrix=False`` by default.
     """
 

--- a/src/qiboml/models/utils.py
+++ b/src/qiboml/models/utils.py
@@ -1,0 +1,12 @@
+def _get_wire_names_and_qubits(nqubits, qubits):
+    if qubits is not None:
+        if isinstance(qubits[0], str):
+            wire_names = qubits
+            qubits = tuple(range(len(qubits)))
+        else:
+            qubits = tuple(qubits)
+            wire_names = None
+    else:
+        qubits = tuple(range(nqubits))
+        wire_names = None
+    return qubits, wire_names


### PR DESCRIPTION
This gives the possibility to set the ``wire_names`` in encoders and ansatze through their ``qubits`` argument. This is mostly useful for selecting the qubits to use when running on hardware.
