### PR TITLE
Speeding up `JAX` backend using jitting

### DIFF
--- a/src/qiboml/backends/jax.py
+++ b/src/qiboml/backends/jax.py
@@ -159,9 +159,7 @@ class JaxBackend(NumpyBackend):
         return matrix
 
     def zero_state(self, nqubits):
-        state = self.np.zeros(2**nqubits, dtype=self.dtype)
-        state = state.at[0].set(1)
-        return state
+        return zero_state(nqubits, self.dtype)
 
     def zero_density_matrix(self, nqubits):
         state = self.np.zeros(2 * (2**nqubits,), dtype=self.dtype)
@@ -250,6 +248,3 @@ class JaxBackend(NumpyBackend):
             state = self.np.einsum(right, state, matrixc)
             state = self.np.einsum(left, state, matrix)
         return self.np.reshape(state, 2 * (2**nqubits,))
-
-    def zero_state(self, nqubits):
-        return zero_state(nqubits, self.dtype)

--- a/src/qiboml/backends/jax.py
+++ b/src/qiboml/backends/jax.py
@@ -11,15 +11,15 @@ from qibo.backends.numpy import NumpyBackend
 from qibo.config import raise_error
 
 
-class JaxMatrices(NumpyMatrices):
+@partial(jax.jit, static_argnums=(0, 1))
+def zero_state(nqubits, dtype):
+    state = jnp.zeros(2**nqubits, dtype=dtype).at[0].set(1)
+    return state
 
-    def __init__(self, dtype):
-        super().__init__(dtype)
-        self.np = jnp
-        self.dtype = dtype
 
-    def _cast(self, x, dtype):
-        return jnp.asarray(x, dtype=dtype)
+@partial(jax.jit, static_argnames={"dtype"})
+def cast_matrix(x, dtype):
+    return jnp.asarray(x, dtype=dtype)
 
 
 @partial(jax.jit, static_argnums=(2, 3))
@@ -52,6 +52,17 @@ def _apply_gate_controlled(
     # Put qubit indices back to their proper places
     state = jnp.transpose(state, einsum_utils.reverse_order(order))
     return jnp.reshape(state, (2**nqubits,))
+
+
+class JaxMatrices(NumpyMatrices):
+
+    def __init__(self, dtype):
+        super().__init__(dtype)
+        self.np = jnp
+        self.dtype = dtype
+
+    def _cast(self, x, dtype):
+        return cast_matrix(x, dtype)
 
 
 class JaxBackend(NumpyBackend):
@@ -239,3 +250,6 @@ class JaxBackend(NumpyBackend):
             state = self.np.einsum(right, state, matrixc)
             state = self.np.einsum(left, state, matrix)
         return self.np.reshape(state, 2 * (2**nqubits,))
+
+    def zero_state(self, nqubits):
+        return zero_state(nqubits, self.dtype)

--- a/src/qiboml/backends/jax.py
+++ b/src/qiboml/backends/jax.py
@@ -17,6 +17,12 @@ def zero_state(nqubits, dtype):
     return state
 
 
+@partial(jax.jit, static_argnums=(0, 1))
+def zero_density_matrix(nqubits, dtype):
+    matrix = jnp.zeros(2 * (2**nqubits,), dtype=dtype).at[0, 0].set(1)
+    return matrix
+
+
 @partial(jax.jit, static_argnames={"dtype"})
 def cast_matrix(x, dtype):
     return jnp.asarray(x, dtype=dtype)
@@ -162,9 +168,7 @@ class JaxBackend(NumpyBackend):
         return zero_state(nqubits, self.dtype)
 
     def zero_density_matrix(self, nqubits):
-        state = self.np.zeros(2 * (2**nqubits,), dtype=self.dtype)
-        state = state.at[0, 0].set(1)
-        return state
+        return zero_density_matrix(nqubits, self.dtype)
 
     def plus_state(self, nqubits):
         state = self.np.ones(2**nqubits, dtype=self.dtype)


### PR DESCRIPTION
In this PR I jitted some functions in the jax backend to improve performances.
Here is a quick benchmark on my laptop.
<details closed>
<summary>main</summary>
<br>

![test_qiboml_main](https://github.com/user-attachments/assets/7165e14c-8754-42a7-93e8-dd74c7d71c08)


</details>

<details closed>
<summary>jit-jax</summary>
<br>

![test_qiboml_pr](https://github.com/user-attachments/assets/0957e1f2-5273-4ec3-a7b9-2630e99c62e7)



</details>

It seems that just with these few improvements we can get performances almost like numba.
I will try to launch the benchmark on the cluster trying to push for a higher number of qubits.