### PR TITLE
Add min iterations gap and custom number of shots to real time mitigation

### DIFF
--- a/src/qiboml/models/utils.py
+++ b/src/qiboml/models/utils.py
@@ -34,6 +34,8 @@ class Mitigator:
 
         cfg = self.mitigation_config or {}
         self._threshold = cfg.get("threshold", 1e-1)
+        self._min_iterations = cfg.get("min_iterations", 100)
+        self._iteration_counter = 0
         self._mitigation_method = cfg.get("method", "cdr")
         self._mitigation_method_kwargs = cfg.get("method_kwargs", {})
 
@@ -128,7 +130,6 @@ class Mitigator:
             circuit=circuit,
             observable=observable,
             noise_model=noise_model,
-            nshots=nshots,
             full_output=True,
             **self._mitigation_method_kwargs,
         )


### PR DESCRIPTION
Improvs here:

1. we can set a number of `min_iterations` which pass before checking and - eventually - recomputing the map;
2. the number of shots is customizable in the decoder, and this improves the performances of mitigation. 