### PR TITLE
Align wires names attribute with input circuit in Decoding when real time mitigating

### DIFF
--- a/src/qiboml/models/decoding.py
+++ b/src/qiboml/models/decoding.py
@@ -86,10 +86,7 @@ class QuantumDecoding:
         """
         # Standardize the density matrix attribute
         self._align_density_matrix(x)
-
-        wire_names = list(self.wire_names) if self.wire_names is not None else None
-        x.wire_names = wire_names
-        x.init_kwargs["wire_names"] = wire_names
+        self._align_wire_names(x)
 
         if self.transpiler is not None:
             x, _ = self.transpiler(x)
@@ -147,6 +144,12 @@ class QuantumDecoding:
         # Aligning the density_matrix attribute of all the circuits
         self._circuit.init_kwargs["density_matrix"] = density_matrix
         x.init_kwargs["density_matrix"] = density_matrix
+
+    def _align_wire_names(self, x: Circuit):
+        """Share the wire names with the input circuit."""
+        wire_names = list(self.wire_names) if self.wire_names is not None else None
+        x.wire_names = wire_names
+        x.init_kwargs["wire_names"] = wire_names
 
     @contextmanager
     def _temporary_nshots(self, nshots):
@@ -269,6 +272,7 @@ class Expectation(QuantumDecoding):
         if self.mitigation_config is not None:
             # In this case it is required before the super.call
             self._align_density_matrix(x)
+            self._align_wire_names(x)
             _real_time_mitigation_check(self, x)
 
         # run circuit


### PR DESCRIPTION
As per title.
This has to be done before the `super.__call__` when doing real time mitigation.