### PR TITLE
Differentiation rules now are built after being instantiated

### DIFF
--- a/src/qiboml/interfaces/keras.py
+++ b/src/qiboml/interfaces/keras.py
@@ -22,10 +22,10 @@ from qiboml.models.encoding import QuantumEncoding
 from qiboml.operations.differentiation import PSR, Differentiation, Jax
 
 DEFAULT_DIFFERENTIATION = {
-    "qiboml-pytorch": Jax,
+    "qiboml-pytorch": Jax(),
     "qiboml-tensorflow": None,
-    "qiboml-jax": Jax,
-    "numpy": Jax,
+    "qiboml-jax": Jax(),
+    "numpy": Jax(),
 }
 
 
@@ -134,7 +134,7 @@ class QuantumModel(keras.Model):  # pylint: disable=no-member
             self.differentiation = utils.get_default_differentiation(
                 decoding=self.decoding,
                 instructions=DEFAULT_DIFFERENTIATION,
-            )
+            )()
         self.custom_gradient = None
 
     def compute_output_shape(self, input_shape):
@@ -149,8 +149,8 @@ class QuantumModel(keras.Model):  # pylint: disable=no-member
             )
             output = self.decoding(circuit)
             return output[None, :]
-        if self.custom_gradient is None:
-            self.differentiation = self.differentiation(
+        if not self.differentiation._is_built:
+            self.differentiation.build_differentiation(
                 self.circuit_tracer.build_circuit(1 * self.circuit_parameters, x=x),
                 self.decoding,
             )

--- a/src/qiboml/interfaces/pytorch.py
+++ b/src/qiboml/interfaces/pytorch.py
@@ -18,9 +18,9 @@ from qiboml.operations.differentiation import PSR, Differentiation, Jax
 
 DEFAULT_DIFFERENTIATION = {
     "qiboml-pytorch": None,
-    "qiboml-tensorflow": Jax,
-    "qiboml-jax": Jax,
-    "numpy": Jax,
+    "qiboml-tensorflow": Jax(),
+    "qiboml-jax": Jax(),
+    "numpy": Jax(),
 }
 
 
@@ -65,8 +65,10 @@ class QuantumModel(torch.nn.Module):
             to pass a single circuit, in the case a sequential structure is not needed.
         decoding (QuantumDecoding): the decoding layer.
         differentiation (Differentiation, optional): the differentiation engine,
-            if not provided a default one will be picked following what described in the :ref:`docs <_differentiation_engine>`.
-        circuit_tracer (CircuitTracer, optional): tracer used to build the circuit and trace the operations performed upon construction. Defaults to ``TorchCircuitTracer``.
+            if not provided a default one will be picked following what described in
+            the :ref:`docs <_differentiation_engine>`.
+        circuit_tracer (CircuitTracer, optional): tracer used to build the circuit
+        and trace the operations performed upon construction. Defaults to ``TorchCircuitTracer``.
     """
 
     circuit_structure: Union[Circuit, List[Union[Circuit, QuantumEncoding, Callable]]]
@@ -99,7 +101,7 @@ class QuantumModel(torch.nn.Module):
                 self.differentiation = utils.get_default_differentiation(
                     decoding=self.decoding,
                     instructions=DEFAULT_DIFFERENTIATION,
-                )
+                )()
 
     def forward(self, x: Optional[torch.Tensor] = None):
         """
@@ -118,8 +120,8 @@ class QuantumModel(torch.nn.Module):
             )
             x = self.decoding(circuit)
         else:
-            if isinstance(self.differentiation, type):
-                self.differentiation = self.differentiation(
+            if not self.differentiation._is_built:
+                self.differentiation.build_differentiation(
                     self.circuit_tracer.build_circuit(list(self.parameters())[0], x=x),
                     self.decoding,
                 )


### PR DESCRIPTION
As per title.
This allows custom diffrules like `QuimbJax` to be customized before a `circuit` or a `decoder` are needed.