### PR TITLE
Add `QuantumNaturalGradient` optimizer

### DIFF
--- a/doc/source/advanced/optimizers.rst
+++ b/doc/source/advanced/optimizers.rst
@@ -1,5 +1,47 @@
+Using the Quantum Natural Gradient Optimizer
+--------------------------------------------
+
+The Quantum Natural Gradient (QNG) optimizer updates variational-circuit
+parameters using the quantum Fisher information matrix as a local metric tensor.
+In ``qiboml``, it is implemented in
+:class:`qiboml.models.optimizers.QuantumNaturalGradient`.
+
+The optimizer works with any parametrized :class:`qibo.Circuit`, a callable loss
+function, and either a user-provided Euclidean gradient function or a central
+finite-difference gradient. The QFIM itself is calculated with
+``qibo.quantum_info.quantum_fisher_information_matrix`` and therefore requires a
+backend that supports the QFIM Jacobian calculation.
+
+Example usage
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from qibo import Circuit, gates, get_backend, set_backend
+    from qiboml.models.optimizers import QuantumNaturalGradient
+
+    set_backend("qiboml", platform="pytorch")
+    backend = get_backend()
+
+    circuit = Circuit(1)
+    circuit.add(gates.RY(0, theta=0.2))
+
+    def loss_fn(circuit, backend):
+        state = backend.execute_circuit(circuit).state()
+        return backend.real(backend.conj(state[1]) * state[1])
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        learning_rate=0.05,
+        regularization=1e-8,
+        backend=backend,
+    )
+    final_loss, losses, final_params = optimizer(steps=20)
+
+
 Using the Exact Geodesic Transport with Conjugate Gradients(EGT-CG) Optimizer
--------------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 
 The Exact Geodesic Transport with Conjugate Gradients (EGT-CG) optimizer is a curvature-aware Riemannian optimizer designed specifically for variational circuits based on the Hamming-weight encoder (HWE) ansatz (see  Farias et al., *Quantum encoder for fixed-Hamming-weight subspaces*, `Phys. Rev. Applied 23, 044014 (2025) <https://doi.org/10.1103/PhysRevApplied.23.044014>`_).
 

--- a/doc/source/advanced/optimizers.rst
+++ b/doc/source/advanced/optimizers.rst
@@ -28,7 +28,7 @@ Example usage
 
     hamiltonian = XXZ(nqubits, backend=backend).matrix
 
-    circuit = Circuit(1)
+    circuit = Circuit(nqubits)
     circuit.add(gates.RY(qubit, theta=backend.random_sample(1)) for qubit in range(nqubits))
     circuit.add(gates.CNOT(qubit, qubit + 1) for qubit in range(nqubits - 1))
     circuit.add(gates.RY(qubit, theta=backend.random_sample(1)) for qubit in range(nqubits))

--- a/doc/source/advanced/optimizers.rst
+++ b/doc/source/advanced/optimizers.rst
@@ -2,7 +2,7 @@ Using the Quantum Natural Gradient Optimizer
 --------------------------------------------
 
 The Quantum Natural Gradient (QNG) optimizer updates variational-circuit
-parameters using the quantum Fisher information matrix as a local metric tensor.
+parameters using the quantum Fisher information matrix (QFIM) as a local metric tensor.
 In ``qiboml``, it is implemented in
 :class:`qiboml.models.optimizers.QuantumNaturalGradient`.
 
@@ -10,7 +10,7 @@ The optimizer works with any parametrized :class:`qibo.Circuit`, a callable loss
 function, and either a user-provided Euclidean gradient function or a central
 finite-difference gradient. The QFIM itself is calculated with
 ``qibo.quantum_info.quantum_fisher_information_matrix`` and therefore requires a
-backend that supports the QFIM Jacobian calculation.
+backend that supports the QFIM's Jacobian calculation.
 
 Example usage
 ~~~~~~~~~~~~~
@@ -18,17 +18,24 @@ Example usage
 .. code-block:: python
 
     from qibo import Circuit, gates, get_backend, set_backend
+    from qibo.hamiltonians import XXZ
     from qiboml.models.optimizers import QuantumNaturalGradient
 
     set_backend("qiboml", platform="pytorch")
     backend = get_backend()
 
+    nqubits = 2
+
+    hamiltonian = XXZ(nqubits, backend=backend).matrix
+
     circuit = Circuit(1)
-    circuit.add(gates.RY(0, theta=0.2))
+    circuit.add(gates.RY(qubit, theta=backend.random_sample(1)) for qubit in range(nqubits))
+    circuit.add(gates.CNOT(qubit, qubit + 1) for qubit in range(nqubits - 1))
+    circuit.add(gates.RY(qubit, theta=backend.random_sample(1)) for qubit in range(nqubits))
 
     def loss_fn(circuit, backend):
         state = backend.execute_circuit(circuit).state()
-        return backend.real(backend.conj(state[1]) * state[1])
+        return backend.real(backend.conj(state) @ hamiltonian @ state)
 
     optimizer = QuantumNaturalGradient(
         circuit,
@@ -134,4 +141,4 @@ At the end of the run, the following objects are returned:
 - ``losses``: List of losses per epoch.
 - ``final_params``: Final parameters.
 
-Also, one can access the arttributes ``n_calls_loss`` and ``n_calls_gradient``, which store respectively the number of times that the loss and the gradient were computed during the optimization.
+Also, one can access the attributes ``n_calls_loss`` and ``n_calls_gradient``, which store respectively the number of times that the loss and the gradient were computed during the optimization.

--- a/doc/source/api-reference/qiboml.models.rst
+++ b/doc/source/api-reference/qiboml.models.rst
@@ -39,6 +39,11 @@ qiboml.models.decoding
 qiboml.models.optimizers
 ------------------------
 
+.. autoclass:: qiboml.models.optimizers.QuantumNaturalGradient
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. autoclass:: qiboml.models.optimizers.ExactGeodesicTransportCG
    :members:
    :undoc-members:

--- a/src/qiboml/backends/jax.py
+++ b/src/qiboml/backends/jax.py
@@ -278,6 +278,24 @@ class JaxBackend(Backend):
 
         return _apply_gate(gate.matrix(self), state, gate.qubits, nqubits)
 
+    def jacobian(
+        self,
+        circuit,
+        parameters: Optional[ArrayLike] = None,
+        initial_state: Optional[ArrayLike] = None,
+        return_complex: bool = True,
+    ) -> ArrayLike:
+        copied = circuit.copy(deep=True)
+
+        def func(parameters):
+            copied.set_parameters(parameters)
+            state = self.execute_circuit(copied, initial_state=initial_state).state()
+            if return_complex:
+                return self.real(state), self.imag(state)
+            return self.real(state)
+
+        return self.jax.jacobian(func)(parameters)
+
     def matrix(self, gate: Gate) -> ArrayLike:
         matrix = super().matrix(gate)
         if isinstance(matrix, self.jax.core.Tracer):

--- a/src/qiboml/models/optimizers.py
+++ b/src/qiboml/models/optimizers.py
@@ -1,6 +1,7 @@
 import math
 from typing import Any, Callable, Tuple
 
+import numpy as np
 from numpy.typing import ArrayLike
 from qibo import Circuit
 from qibo.backends import Backend, _check_backend
@@ -10,9 +11,271 @@ from qibo.models.encodings import (
     _generate_rbs_angles,
     hamming_weight_encoder,
 )
-from qibo.quantum_info import random_statevector
+from qibo.quantum_info import quantum_fisher_information_matrix, random_statevector
 from scipy.sparse import issparse, isspmatrix_coo
 from scipy.special import comb
+
+
+class QuantumNaturalGradient:
+    r"""Quantum Natural Gradient optimizer for parametrized circuits.
+
+    Implements the Quantum Natural Gradient update rule
+
+    .. math::
+
+        \theta_{t + 1} = \theta_t - \eta (F(\theta_t) + \lambda I)^+ \nabla L,
+
+    where :math:`F(\theta)` is the quantum Fisher information matrix (QFIM).
+
+    Args:
+        circuit (:class:`qibo.models.circuit.Circuit`): Parametrized circuit to optimize.
+        loss_fn (Callable): Loss function. The first two arguments must be the circuit
+            and backend used for execution.
+        loss_kwargs (dict, optional): Additional keyword arguments for ``loss_fn``.
+        initial_parameters (ArrayLike, optional): Initial circuit parameters. If ``None``,
+            the parameters already stored in ``circuit`` are used.
+        gradient_fn (Callable, optional): Function returning the Euclidean gradient with
+            respect to the circuit parameters. The first two arguments must be the circuit
+            and backend. If ``None``, a central finite-difference gradient is used.
+        gradient_kwargs (dict, optional): Additional keyword arguments for
+            ``gradient_fn``.
+        learning_rate (float, optional): QNG step size. Defaults to ``0.01``.
+        regularization (float, optional): Non-negative diagonal regularization added to
+            the QFIM before solving the natural-gradient system. Defaults to ``1e-8``.
+        finite_difference_epsilon (float, optional): Shift used when ``gradient_fn`` is
+            not provided. Defaults to ``1e-6``.
+        qfim_kwargs (dict, optional): Additional keyword arguments passed to
+            :func:`qibo.quantum_info.quantum_fisher_information_matrix`, such as
+            ``initial_state`` or ``return_complex``.
+        callback (Callable, optional): Function called after every optimization step with
+            keyword arguments ``iter_num``, ``loss``, ``parameters``, and
+            ``natural_gradient``.
+        backend (:class:`qibo.backends.abstract.Backend`, optional): Execution backend.
+            If ``None``, the current qibo backend is used.
+
+    Returns:
+        :class:`qiboml.models.optimizers.QuantumNaturalGradient`: Instantiated optimizer.
+
+    References:
+        J. Stokes, J. Izaac, N. Killoran, and G. Carleo, *Quantum Natural Gradient*,
+        `Quantum 4, 269 (2020) <https://doi.org/10.22331/q-2020-05-25-269>`_.
+    """
+
+    def __init__(
+        self,
+        circuit: Circuit,
+        loss_fn: Callable[..., float],
+        loss_kwargs: dict | None = None,
+        initial_parameters: ArrayLike | None = None,
+        gradient_fn: Callable[..., ArrayLike] | None = None,
+        gradient_kwargs: dict | None = None,
+        learning_rate: float = 0.01,
+        regularization: float = 1e-8,
+        finite_difference_epsilon: float = 1e-6,
+        qfim_kwargs: dict | None = None,
+        callback: Callable[..., None] | None = None,
+        backend: Backend = None,
+    ):
+        if not isinstance(circuit, Circuit):
+            raise_error(
+                TypeError,
+                "``circuit`` must be an instance of ``qibo.models.circuit.Circuit``.",
+            )
+        if not callable(loss_fn):
+            raise_error(TypeError, "``loss_fn`` must be callable.")
+        if gradient_fn is not None and not callable(gradient_fn):
+            raise_error(TypeError, "``gradient_fn`` must be callable or ``None``.")
+        if learning_rate <= 0:
+            raise_error(ValueError, "``learning_rate`` must be positive.")
+        if regularization < 0:
+            raise_error(ValueError, "``regularization`` must be non-negative.")
+        if finite_difference_epsilon <= 0:
+            raise_error(ValueError, "``finite_difference_epsilon`` must be positive.")
+
+        self.circuit = circuit
+        self.loss_fn = loss_fn
+        self.loss_kwargs = {} if loss_kwargs is None else loss_kwargs
+        self.gradient_fn = gradient_fn
+        self.gradient_kwargs = {} if gradient_kwargs is None else gradient_kwargs
+        self.learning_rate = learning_rate
+        self.regularization = regularization
+        self.finite_difference_epsilon = finite_difference_epsilon
+        self.qfim_kwargs = {} if qfim_kwargs is None else qfim_kwargs
+        self.callback = callback
+        self.backend = _check_backend(backend)
+
+        self.n_calls_loss = 0
+        self.n_calls_gradient = 0
+        self.n_calls_qfim = 0
+
+        if initial_parameters is not None:
+            self.circuit.set_parameters(self._as_flat_array(initial_parameters))
+
+        self.parameters = self.current_parameters()
+        if len(self.parameters) == 0:
+            raise_error(
+                ValueError,
+                "``QuantumNaturalGradient`` requires a parametrized circuit.",
+            )
+
+    def _as_flat_array(self, values: ArrayLike) -> np.ndarray:
+        if hasattr(self.backend, "to_numpy"):
+            values = self.backend.to_numpy(values)
+        return np.asarray(values, dtype=float).reshape(-1)
+
+    def _as_scalar(self, value: Any) -> float:
+        if hasattr(self.backend, "to_numpy"):
+            value = self.backend.to_numpy(value)
+        return float(np.asarray(value).reshape(()))
+
+    def current_parameters(self) -> np.ndarray:
+        """Return current circuit parameters as a flat NumPy array."""
+        return self._as_flat_array(
+            self.circuit.get_parameters(output_format="flatlist")
+        )
+
+    def loss(
+        self, circuit: Circuit | None = None, backend: Backend | None = None
+    ) -> float:
+        """Evaluate the loss and increment the loss-call counter."""
+        self.n_calls_loss += 1
+        if circuit is None:
+            circuit = self.circuit
+        if backend is None:
+            backend = self.backend
+        return self._as_scalar(self.loss_fn(circuit, backend, **self.loss_kwargs))
+
+    def metric_tensor(self) -> np.ndarray:
+        """Calculate the QFIM for the current circuit parameters."""
+        parameters = self.current_parameters()
+        qfim_parameters = self.backend.cast(parameters, dtype=self.backend.float64)
+        kwargs = dict(self.qfim_kwargs)
+        self.n_calls_qfim += 1
+        try:
+            metric = quantum_fisher_information_matrix(
+                self.circuit,
+                parameters=qfim_parameters,
+                backend=self.backend,
+                **kwargs,
+            )
+        except NotImplementedError as exc:
+            raise NotImplementedError(
+                "``QuantumNaturalGradient`` requires a qibo backend whose "
+                + "``quantum_fisher_information_matrix`` supports automatic "
+                + "differentiation, or a custom compatible backend. "
+                + f"Current backend platform is {self.backend.platform!r}."
+            ) from exc
+
+        metric = self._as_flat_matrix(metric)
+        if metric.shape != (len(parameters), len(parameters)):
+            raise_error(
+                ValueError,
+                "The QFIM shape must match the number of trainable parameters. "
+                + f"Expected {(len(parameters), len(parameters))}, got {metric.shape}.",
+            )
+        return metric
+
+    def _as_flat_matrix(self, values: ArrayLike) -> np.ndarray:
+        if hasattr(self.backend, "to_numpy"):
+            values = self.backend.to_numpy(values)
+        values = np.asarray(values, dtype=float)
+        if values.ndim != 2:
+            raise_error(ValueError, "The QFIM must be a two-dimensional matrix.")
+        return values
+
+    def gradient(self) -> np.ndarray:
+        """Return the Euclidean gradient of the loss."""
+        self.n_calls_gradient += 1
+        if self.gradient_fn is not None:
+            gradient = self.gradient_fn(
+                self.circuit, self.backend, **self.gradient_kwargs
+            )
+            gradient = self._as_flat_array(gradient)
+        else:
+            gradient = self._finite_difference_gradient()
+
+        if len(gradient) != len(self.current_parameters()):
+            raise_error(
+                ValueError,
+                "The gradient length must match the number of trainable parameters. "
+                + f"Expected {len(self.current_parameters())}, got {len(gradient)}.",
+            )
+        return gradient
+
+    def _finite_difference_gradient(self) -> np.ndarray:
+        params = self.current_parameters()
+        gradient = np.zeros_like(params, dtype=float)
+        epsilon = self.finite_difference_epsilon
+
+        for index in range(len(params)):
+            shifted = params.copy()
+            shifted[index] += epsilon
+            self.circuit.set_parameters(shifted)
+            loss_plus = self.loss()
+
+            shifted[index] -= 2 * epsilon
+            self.circuit.set_parameters(shifted)
+            loss_minus = self.loss()
+
+            gradient[index] = (loss_plus - loss_minus) / (2 * epsilon)
+
+        self.circuit.set_parameters(params)
+        return gradient
+
+    def natural_gradient(self) -> np.ndarray:
+        """Solve the regularized QNG linear system."""
+        metric = self.metric_tensor()
+        gradient = self.gradient()
+        if self.regularization:
+            metric = metric + self.regularization * np.eye(len(gradient))
+
+        try:
+            return np.linalg.solve(metric, gradient)
+        except np.linalg.LinAlgError:
+            return np.linalg.pinv(metric) @ gradient
+
+    def run(self, steps: int = 100) -> Tuple[float, ArrayLike, ArrayLike]:
+        """Run QNG optimization for ``steps`` iterations.
+
+        Args:
+            steps (int, optional): Number of optimization iterations. Defaults to ``100``.
+
+        Returns:
+            Tuple[float, ArrayLike, ArrayLike]:
+                final loss, losses at the initial and intermediate parameters,
+                and final parameters.
+        """
+        if steps < 0:
+            raise_error(ValueError, "``steps`` must be non-negative.")
+
+        losses = [self.loss()]
+        for iter_num in range(steps):
+            params = self.current_parameters()
+            natural_gradient = self.natural_gradient()
+            updated_parameters = params - self.learning_rate * natural_gradient
+            self.circuit.set_parameters(updated_parameters)
+
+            loss_value = self.loss()
+            losses.append(loss_value)
+
+            if self.callback is not None:
+                self.callback(
+                    iter_num=iter_num + 1,
+                    loss=loss_value,
+                    parameters=updated_parameters,
+                    natural_gradient=natural_gradient,
+                )
+
+        self.parameters = self.current_parameters()
+        return (
+            losses[-1],
+            self.backend.cast(losses, dtype=self.backend.float64),
+            self.backend.cast(self.parameters, dtype=self.backend.float64),
+        )
+
+    def __call__(self, steps: int = 100) -> Tuple[float, ArrayLike, ArrayLike]:
+        """Run QNG optimization for ``steps`` iterations."""
+        return self.run(steps=steps)
 
 
 class ExactGeodesicTransportCG:

--- a/tests/test_models_optimizers.py
+++ b/tests/test_models_optimizers.py
@@ -1,13 +1,174 @@
+import numpy as np
 import pytest
 import scipy
-from qibo import hamiltonians
+from qibo import Circuit, gates, hamiltonians
 from qibo.backends import NumpyBackend
 from qibo.models.encodings import _generate_rbs_angles
 from qibo.quantum_info import random_statevector
 from scipy.sparse import csr_matrix
 from scipy.special import comb
 
-from qiboml.models.optimizers import ExactGeodesicTransportCG
+from qiboml.models import optimizers
+from qiboml.models.optimizers import ExactGeodesicTransportCG, QuantumNaturalGradient
+
+
+def test_quantum_natural_gradient_uses_qfim(monkeypatch):
+    backend = NumpyBackend()
+    circuit = Circuit(2)
+    circuit.add(gates.RY(0, theta=1.0))
+    circuit.add(gates.RZ(1, theta=1.0))
+    qfim_calls = []
+
+    def loss_fn(circuit, backend):
+        params = np.asarray(circuit.get_parameters(output_format="flatlist"))
+        target = np.asarray([0.0, -1.0])
+        return float(np.sum((params - target) ** 2))
+
+    def gradient_fn(circuit, backend):
+        params = np.asarray(circuit.get_parameters(output_format="flatlist"))
+        target = np.asarray([0.0, -1.0])
+        return 2 * (params - target)
+
+    def qfim(circuit, parameters=None, **kwargs):
+        qfim_calls.append(np.asarray(parameters))
+        return np.diag([2.0, 4.0])
+
+    monkeypatch.setattr(optimizers, "quantum_fisher_information_matrix", qfim)
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        gradient_fn=gradient_fn,
+        learning_rate=0.5,
+        regularization=0.0,
+        backend=backend,
+    )
+    final_loss, losses, final_parameters = optimizer(steps=1)
+
+    np.testing.assert_allclose(final_parameters, [0.5, 0.5])
+    assert final_loss < losses[0]
+    assert optimizer.n_calls_qfim == 1
+    np.testing.assert_allclose(qfim_calls[0], [1.0, 1.0])
+
+
+def test_quantum_natural_gradient_regularizes_singular_qfim(monkeypatch):
+    backend = NumpyBackend()
+    circuit = Circuit(2)
+    circuit.add(gates.RY(0, theta=1.0))
+    circuit.add(gates.RZ(1, theta=1.0))
+
+    def loss_fn(circuit, backend):
+        params = np.asarray(circuit.get_parameters(output_format="flatlist"))
+        return float(np.sum(params**2))
+
+    def gradient_fn(circuit, backend):
+        return np.asarray([1.0, 2.0])
+
+    monkeypatch.setattr(
+        optimizers,
+        "quantum_fisher_information_matrix",
+        lambda *args, **kwargs: np.zeros((2, 2)),
+    )
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        gradient_fn=gradient_fn,
+        learning_rate=0.25,
+        regularization=1.0,
+        backend=backend,
+    )
+    _, _, final_parameters = optimizer(steps=1)
+
+    np.testing.assert_allclose(final_parameters, [0.75, 0.5])
+
+
+def test_quantum_natural_gradient_finite_difference_gradient(monkeypatch):
+    backend = NumpyBackend()
+    circuit = Circuit(1)
+    circuit.add(gates.RY(0, theta=0.4))
+
+    def loss_fn(circuit, backend):
+        param = circuit.get_parameters(output_format="flatlist")[0]
+        return float(param**2)
+
+    monkeypatch.setattr(
+        optimizers,
+        "quantum_fisher_information_matrix",
+        lambda *args, **kwargs: np.eye(1),
+    )
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        learning_rate=0.1,
+        regularization=0.0,
+        finite_difference_epsilon=1e-7,
+        backend=backend,
+    )
+    final_loss, losses, final_parameters = optimizer(steps=1)
+
+    np.testing.assert_allclose(final_parameters, [0.32], atol=1e-6)
+    assert final_loss < losses[0]
+    assert optimizer.n_calls_gradient == 1
+
+
+def test_quantum_natural_gradient_uses_separate_gradient_kwargs(monkeypatch):
+    backend = NumpyBackend()
+    circuit = Circuit(1)
+    circuit.add(gates.RY(0, theta=1.0))
+
+    def loss_fn(circuit, backend, offset):
+        param = circuit.get_parameters(output_format="flatlist")[0]
+        return float((param - offset) ** 2)
+
+    def gradient_fn(circuit, backend, scale):
+        param = circuit.get_parameters(output_format="flatlist")[0]
+        return np.asarray([scale * param])
+
+    monkeypatch.setattr(
+        optimizers,
+        "quantum_fisher_information_matrix",
+        lambda *args, **kwargs: np.eye(1),
+    )
+
+    optimizer = QuantumNaturalGradient(
+        circuit,
+        loss_fn=loss_fn,
+        loss_kwargs={"offset": 0.0},
+        gradient_fn=gradient_fn,
+        gradient_kwargs={"scale": 3.0},
+        learning_rate=0.1,
+        regularization=0.0,
+        backend=backend,
+    )
+    final_loss, losses, final_parameters = optimizer(steps=1)
+
+    np.testing.assert_allclose(final_parameters, [0.7])
+    assert final_loss < losses[0]
+
+
+def test_quantum_natural_gradient_errors():
+    backend = NumpyBackend()
+    circuit = Circuit(1)
+
+    with pytest.raises(ValueError):
+        _ = QuantumNaturalGradient(
+            circuit, loss_fn=lambda circuit, backend: 0, backend=backend
+        )
+
+    circuit.add(gates.RY(0, theta=0.1))
+
+    with pytest.raises(ValueError):
+        _ = QuantumNaturalGradient(
+            circuit,
+            loss_fn=lambda circuit, backend: 0,
+            learning_rate=0,
+            backend=backend,
+        )
+
+    with pytest.raises(TypeError):
+        _ = QuantumNaturalGradient(circuit, loss_fn=1, backend=backend)
 
 
 def test_egt_cg_errors(backend):


### PR DESCRIPTION
## Summary
- Add a `QuantumNaturalGradient` optimizer for parametrized `qibo.Circuit` objects.
- Use `qibo.quantum_info.quantum_fisher_information_matrix` to build the QFIM metric tensor and solve the regularized natural-gradient system.
- Support user-provided Euclidean gradients, separate `gradient_kwargs`, and a central finite-difference fallback.
- Add a JAX backend `jacobian` implementation so qibo QFIM can run through the qiboml JAX backend as well as the existing PyTorch/TensorFlow jacobian paths.
- Add optimizer tests, advanced docs, and API reference coverage.

## Validation
- `python -m pytest tests/test_models_optimizers.py -q -o addopts=''`
- `python -m black --check src/qiboml/models/optimizers.py src/qiboml/backends/jax.py tests/test_models_optimizers.py`
- `python -m py_compile src/qiboml/models/optimizers.py src/qiboml/backends/jax.py tests/test_models_optimizers.py`
- `git diff --check`

Closes #207