### PR TITLE
Add QuantumNaturalGradient optimizer

### DIFF
--- a/doc/source/advanced/optimizers.rst
+++ b/doc/source/advanced/optimizers.rst
@@ -7,7 +7,7 @@ It updates parameters along exact geodesic paths on the hyperspherical manifold 
 
 For more details, see: Ferreira-Martins et al., *Quantum optimization with exact geodesic transport*, `arXiv:2506.17395 (2025) <https://arxiv.org/abs/2506.17395>`_.
 
-The optimizer works with an ansatz :math:`\ket{\psi(\boldsymbol{\theta})}` parameterized by hyperspherical angles :math:`\boldsymbol{\theta}`, and the implementation allows one to work with arbitrary loss functions. VQE is achieved by specifying the loss function :math:`\mathcal{L}(\boldsymbol{\theta}) = \bra{\psi(\boldsymbol{\theta})} \, H \, \ket{\psi(\boldsymbol{\theta})}` and passing the hamiltonian as one of its arguments, as can be seen in the example below. 
+The optimizer works with an ansatz :math:`\ket{\psi(\boldsymbol{\theta})}` parameterized by hyperspherical angles :math:`\boldsymbol{\theta}`, and the implementation allows one to work with arbitrary loss functions. VQE is achieved by specifying the loss function :math:`\mathcal{L}(\boldsymbol{\theta}) = \bra{\psi(\boldsymbol{\theta})} \, H \, \ket{\psi(\boldsymbol{\theta})}` and passing the hamiltonian as one of its arguments, as can be seen in the example below.
 
 In ``qiboml``, the EGT-CG optimizer is implemented in the class :class:`qiboml.models.optimizers.ExactGeodesicTransportCG`.
 
@@ -85,7 +85,7 @@ As an example, if one wishes to explicitly define the expectation value as the l
         return backend.real(backend.conj(psi) @ hamiltonian @ psi)
 
     loss_fn = loss_func_expval
-  
+
 At the end of the run, the following objects are returned:
 
 - ``final_loss``: Loss at final parameters.
@@ -93,3 +93,81 @@ At the end of the run, the following objects are returned:
 - ``final_params``: Final parameters.
 
 Also, one can access the arttributes ``n_calls_loss`` and ``n_calls_gradient``, which store respectively the number of times that the loss and the gradient were computed during the optimization.
+
+
+Using the Quantum Natural Gradient Optimizer
+--------------------------------------------
+
+The Quantum Natural Gradient (QNG) optimizer is a geometry-aware first-order optimizer for
+generic parametrized circuits. It rescales the gradient using the Fubini-Study metric tensor,
+which in ``qiboml`` is computed from Qibo's Quantum Fisher Information Matrix (QFIM)
+implementation.
+
+For more details, see: Stokes et al., *Quantum Natural Gradient*,
+`arXiv:1909.02108 <https://arxiv.org/abs/1909.02108>`_.
+
+In ``qiboml``, QNG is implemented in the class
+:class:`qiboml.models.optimizers.QuantumNaturalGradient`.
+
+Example usage - VQE with a generic parametrized circuit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from qibo import Circuit, gates, get_backend, set_backend
+    from qibo.hamiltonians import Z
+    from qiboml.models.optimizers import QuantumNaturalGradient
+
+    set_backend("qiboml", platform="pytorch")
+    backend = get_backend()
+
+    circuit = Circuit(2)
+    circuit.add(gates.RY(0, theta=0.1))
+    circuit.add(gates.RY(1, theta=0.2))
+    circuit.add(gates.CZ(0, 1))
+    circuit.add(gates.RY(0, theta=0.3))
+    circuit.add(gates.RY(1, theta=0.4))
+
+    optimizer = QuantumNaturalGradient(
+        circuit=circuit,
+        loss_fn="exp_val",
+        loss_kwargs={"hamiltonian": Z(2, backend=backend).matrix},
+        learning_rate=0.1,
+        regularization=1e-3,
+        backend=backend,
+    )
+    final_loss, losses, final_params = optimizer(steps=50)
+
+
+Available arguments
+~~~~~~~~~~~~~~~~~~
+
+When constructing a :class:`qiboml.models.optimizers.QuantumNaturalGradient` object,
+the arguments are:
+
+- ``circuit``: Parametrized circuit to optimize.
+- ``loss_fn``: Loss function to be optimized. It can be either a callable specifying the
+  loss, or the string ``"exp_val"`` for the standard VQE objective.
+- ``loss_kwargs``: Dictionary of keyword arguments passed to the loss function. If one sets
+  the loss as ``"exp_val"``, the hamiltonian must be passed as
+  ``{'hamiltonian': hamiltonian}``.
+- ``initial_parameters``: Initial circuit parameters. If ``None``, parameters are read from
+  the circuit directly.
+- ``learning_rate``: Step size multiplying the natural-gradient direction.
+- ``regularization``: Diagonal regularization added to the metric tensor before solving the
+  linear system.
+- ``callback``: Callable for callback.
+- ``seed``: Present for API compatibility.
+- ``backend``: Optional qibo backend (default: global backend). Since the metric tensor is
+  computed from Qibo's QFIM implementation, QNG should be used with autodiff-capable backends
+  such as ``qiboml`` with platform ``"pytorch"``, ``"tensorflow"``, or ``"jax"``.
+
+At the end of the run, the following objects are returned:
+
+- ``final_loss``: Loss at final parameters.
+- ``losses``: List of losses per epoch.
+- ``final_params``: Final parameters.
+
+Also, one can access the attributes ``n_calls_loss`` and ``n_calls_gradient``, which store
+respectively the number of times that the loss and the gradient were computed during the
+optimization.

--- a/doc/source/api-reference/qiboml.models.rst
+++ b/doc/source/api-reference/qiboml.models.rst
@@ -39,6 +39,11 @@ qiboml.models.decoding
 qiboml.models.optimizers
 ------------------------
 
+.. autoclass:: qiboml.models.optimizers.QuantumNaturalGradient
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. autoclass:: qiboml.models.optimizers.ExactGeodesicTransportCG
    :members:
    :undoc-members:

--- a/src/qiboml/models/optimizers.py
+++ b/src/qiboml/models/optimizers.py
@@ -1,4 +1,5 @@
 import math
+from types import MethodType
 from typing import Any, Callable, Tuple
 
 import numpy as np
@@ -16,24 +17,6 @@ from qibo.models.encodings import (
 from qibo.quantum_info import quantum_fisher_information_matrix, random_statevector
 from scipy.sparse import issparse, isspmatrix_coo
 from scipy.special import comb
-
-
-class _BackendCastAdapter:
-    """Proxy backend normalizing NumPy dtypes for Qibo internals."""
-
-    def __init__(self, backend: Backend):
-        self._backend = backend
-
-    def cast(self, array, dtype=None, *args, **kwargs):
-        if dtype is not None:
-            try:
-                dtype = getattr(self._backend, np.dtype(dtype).name)
-            except (AttributeError, TypeError):
-                pass
-        return self._backend.cast(array, dtype=dtype, *args, **kwargs)
-
-    def __getattr__(self, name):
-        return getattr(self._backend, name)
 
 
 class QuantumNaturalGradient:
@@ -121,8 +104,10 @@ class QuantumNaturalGradient:
 
         self.loss_fn = loss_fn
         self.hamiltonian = None
+        self.parameter_shift_hamiltonian_matrix = None
         if "hamiltonian" in self.loss_kwargs:
             self.hamiltonian = self.loss_kwargs.get("hamiltonian", None)
+            self.parameter_shift_hamiltonian_matrix = self.hamiltonian
             if not (
                 isinstance(self.hamiltonian, self.backend.tensor_types)
                 or issparse(self.hamiltonian)
@@ -139,9 +124,9 @@ class QuantumNaturalGradient:
                         self.hamiltonian, self.backend
                     )
             else:
-                if self.backend.platform is not None:
+                if self.backend.platform in {"pytorch", "tensorflow"}:
                     self.hamiltonian = self.backend.coo_matrix(self.hamiltonian)
-                else:
+                elif self.backend.platform is None:
                     self.hamiltonian = self.backend.csr_matrix(self.hamiltonian)
 
             self.loss_kwargs["hamiltonian"] = self.hamiltonian
@@ -154,9 +139,16 @@ class QuantumNaturalGradient:
                     + "via the dict item ``{'hamiltonian': hamiltonian}``",
                 )
             self.loss_fn = _loss_func_expval
+            parameter_shift_hamiltonian = self.parameter_shift_hamiltonian_matrix
+            if issparse(parameter_shift_hamiltonian):
+                parameter_shift_hamiltonian = parameter_shift_hamiltonian.toarray()
+                if self.backend.platform is not None:
+                    parameter_shift_hamiltonian = self.backend.cast(
+                        parameter_shift_hamiltonian, dtype=self.backend.dtype
+                    )
             self.parameter_shift_hamiltonian = Hamiltonian(
                 self.circuit.nqubits,
-                self._hamiltonian_to_dense(),
+                parameter_shift_hamiltonian,
                 backend=self.backend,
             )
             self.gradient_func = None
@@ -170,16 +162,49 @@ class QuantumNaturalGradient:
             self.parameter_shift_hamiltonian = None
             self.gradient_func = self._gradient_func_internal
 
-        self.loss = self._loss_internal
-
     def metric_tensor(self) -> ArrayLike:
         """Compute Fubini-Study metric tensor for current circuit parameters."""
 
-        qfim = quantum_fisher_information_matrix(
-            self.circuit,
-            parameters=self.parameters,
-            backend=self.backend,
-        )
+        original_cast = self.backend.cast
+        original_jacobian = getattr(self.backend, "jacobian", None)
+
+        def cast_with_numpy_dtypes(backend, array, dtype=None, copy=False, **kwargs):
+            if dtype is not None:
+                try:
+                    dtype = getattr(backend, np.dtype(dtype).name)
+                except (AttributeError, TypeError):
+                    pass
+            return original_cast(array, dtype=dtype, copy=copy, **kwargs)
+
+        def jax_jacobian(backend, circuit, parameters, initial_state=None, return_complex=True):
+            copied = circuit.copy(deep=True)
+
+            def state_components(params):
+                copied.set_parameters(params)
+                state = backend.execute_circuit(copied, initial_state=initial_state).state()
+                if return_complex:
+                    return backend.real(state), backend.imag(state)
+                return backend.real(state)
+
+            return backend.jax.jacobian(state_components)(parameters)
+
+        self.backend.cast = MethodType(cast_with_numpy_dtypes, self.backend)
+        if self.backend.platform == "jax":
+            self.backend.jacobian = MethodType(jax_jacobian, self.backend)
+
+        try:
+            qfim = quantum_fisher_information_matrix(
+                self.circuit,
+                parameters=self.parameters,
+                backend=self.backend,
+            )
+        finally:
+            self.backend.cast = original_cast
+            if self.backend.platform == "jax":
+                self.backend.jacobian = original_jacobian
+            elif original_jacobian is not None:
+                self.backend.jacobian = original_jacobian
+
         return self.backend.cast(
             self.backend.real(qfim) / 4.0, dtype=self.backend.float64
         )
@@ -227,8 +252,8 @@ class QuantumNaturalGradient:
             dtype=self.backend.float64,
         )
         self.circuit.set_parameters(self.parameters)
-
-        return self.loss(self.circuit, self.backend, **self.loss_kwargs)
+        self.n_calls_loss += 1
+        return self.loss_fn(self.circuit, self.backend, **self.loss_kwargs)
 
     def run_qng(
         self, steps: int = 100, tolerance: float = 1e-8
@@ -264,8 +289,10 @@ class QuantumNaturalGradient:
         final_loss = (
             losses[-1]
             if losses
-            else self.loss(self.circuit, self.backend, **self.loss_kwargs)
+            else self.loss_fn(self.circuit, self.backend, **self.loss_kwargs)
         )
+        if not losses:
+            self.n_calls_loss += 1
         final_parameters = self.parameters
         return (
             self.backend.cast(final_loss, dtype=self.backend.float64),
@@ -280,12 +307,6 @@ class QuantumNaturalGradient:
 
         return self.run_qng(steps=steps, tolerance=tolerance)
 
-    def _loss_internal(self, circuit: Circuit, backend: Backend, **kwargs) -> float:
-        """Wrapper around loss function updating ``n_calls_loss``."""
-
-        self.n_calls_loss += 1
-        return self.loss_fn(circuit, backend, **kwargs)
-
     def _gradient_func_internal(self) -> ArrayLike:
         """Compute backend autodiff gradient for generic callable losses."""
 
@@ -293,18 +314,18 @@ class QuantumNaturalGradient:
 
         platform = self.backend.platform
         if platform == "jax":
-            circuit_orig = self.circuit.copy(deep=True)
+            circuit_copy = self.circuit.copy(deep=True)
 
             def loss_fn(params):
-                self.circuit.set_parameters(params)
-                return self.loss(self.circuit, self.backend, **self.loss_kwargs)
+                circuit_copy.set_parameters(params)
+                self.n_calls_loss += 1
+                return self.loss_fn(circuit_copy, self.backend, **self.loss_kwargs)
 
             params = self.backend.cast(
                 self.circuit.get_parameters(),
                 dtype=self.backend.float64,
             )
             grad = self.backend.jax.grad(loss_fn)(params)
-            self.circuit = circuit_orig.copy(deep=True)
             return grad.reshape(-1)
         if platform == "pytorch":
             params = self.backend.cast(
@@ -312,7 +333,8 @@ class QuantumNaturalGradient:
             )
             params.requires_grad = True
             self.circuit.set_parameters(params)
-            loss = self.loss(self.circuit, self.backend, **self.loss_kwargs)
+            self.n_calls_loss += 1
+            loss = self.loss_fn(self.circuit, self.backend, **self.loss_kwargs)
             loss.backward()
             return params.grad.reshape(-1)
         if platform == "tensorflow":
@@ -322,32 +344,10 @@ class QuantumNaturalGradient:
             )
             with self.backend.engine.GradientTape() as tape:
                 self.circuit.set_parameters(params)
-                loss = self.loss(self.circuit, self.backend, **self.loss_kwargs)
+                self.n_calls_loss += 1
+                loss = self.loss_fn(self.circuit, self.backend, **self.loss_kwargs)
             grad = tape.gradient(loss, params)
             return grad.reshape(-1)
-
-    def _hamiltonian_to_dense(self):
-        """Convert validated Hamiltonian storage to dense array for PSR."""
-
-        if issparse(self.hamiltonian):
-            return self.hamiltonian.toarray()
-
-        if self.backend.platform == "jax" and hasattr(self.hamiltonian, "todense"):
-            return np.asarray(self.hamiltonian.todense())
-
-        if self.backend.platform == "tensorflow" and isinstance(
-            self.hamiltonian, self.backend.engine.sparse.SparseTensor
-        ):
-            return self.backend.to_numpy(
-                self.backend.engine.sparse.to_dense(self.hamiltonian)
-            )
-
-        if self.backend.platform == "pytorch" and getattr(
-            self.hamiltonian, "is_sparse", False
-        ):
-            return self.hamiltonian.to_dense().cpu().numpy(force=True)
-
-        return np.asarray(self.backend.to_numpy(self.hamiltonian))
 
 
 class ExactGeodesicTransportCG:

--- a/src/qiboml/models/optimizers.py
+++ b/src/qiboml/models/optimizers.py
@@ -176,12 +176,16 @@ class QuantumNaturalGradient:
                     pass
             return original_cast(array, dtype=dtype, copy=copy, **kwargs)
 
-        def jax_jacobian(backend, circuit, parameters, initial_state=None, return_complex=True):
+        def jax_jacobian(
+            backend, circuit, parameters, initial_state=None, return_complex=True
+        ):
             copied = circuit.copy(deep=True)
 
             def state_components(params):
                 copied.set_parameters(params)
-                state = backend.execute_circuit(copied, initial_state=initial_state).state()
+                state = backend.execute_circuit(
+                    copied, initial_state=initial_state
+                ).state()
                 if return_complex:
                     return backend.real(state), backend.imag(state)
                 return backend.real(state)

--- a/src/qiboml/models/optimizers.py
+++ b/src/qiboml/models/optimizers.py
@@ -1,18 +1,354 @@
 import math
 from typing import Any, Callable, Tuple
 
+import numpy as np
 from numpy.typing import ArrayLike
 from qibo import Circuit
 from qibo.backends import Backend, _check_backend
 from qibo.config import log, raise_error
+from qibo.derivative import parameter_shift
+from qibo.hamiltonians import Hamiltonian
 from qibo.models.encodings import (
     _ehrlich_algorithm,
     _generate_rbs_angles,
     hamming_weight_encoder,
 )
-from qibo.quantum_info import random_statevector
+from qibo.quantum_info import quantum_fisher_information_matrix, random_statevector
 from scipy.sparse import issparse, isspmatrix_coo
 from scipy.special import comb
+
+
+class _BackendCastAdapter:
+    """Proxy backend normalizing NumPy dtypes for Qibo internals."""
+
+    def __init__(self, backend: Backend):
+        self._backend = backend
+
+    def cast(self, array, dtype=None, *args, **kwargs):
+        if dtype is not None:
+            try:
+                dtype = getattr(self._backend, np.dtype(dtype).name)
+            except (AttributeError, TypeError):
+                pass
+        return self._backend.cast(array, dtype=dtype, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._backend, name)
+
+
+class QuantumNaturalGradient:
+    """Quantum Natural Gradient optimizer.
+
+    Implements the Quantum Natural Gradient (QNG) optimizer based on the
+    Fubini-Study metric of parametrized quantum circuits.
+
+    Args:
+        circuit (qibo.models.circuit.Circuit): Parametrized quantum circuit.
+        loss_fn (str or Callable): If str, only possibility is ``"exp_val"``,
+            for expectation value loss (i.e., running VQE). It can also be a
+            Callable to be used as the loss function. First two arguments
+            (mandatory) are circuit and backend for execution.
+        loss_kwargs (dict, optional): Additional arguments to be passed to the
+            loss function. For VQE (``loss_fn = "exp_val"``), include item
+            ``"hamiltonian": hamiltonian``, where ``hamiltonian`` is passed as
+            ``ArrayLike``, scipy sparse or backend-specific sparse.
+        initial_parameters (ArrayLike, optional): Initial circuit parameters.
+            If ``None``, parameters are read from ``circuit``.
+        learning_rate (float, optional): Gradient step size. Defaults to
+            :math:`10^{-2}`.
+        regularization (float, optional): Tikhonov regularization added to the
+            metric tensor before solving. Defaults to :math:`10^{-3}`.
+        callback (Callable, optional): Callback function receiving keyword
+            arguments ``iter_num``, ``loss``, and ``parameters``.
+        seed (int, optional): Random seed. Present for API compatibility.
+        backend (qibo.backends.abstract.Backend, optional): Backend used for
+            execution. If ``None``, current backend is used.
+
+    Returns:
+        qiboml.models.optimizers.QuantumNaturalGradient: Instantiated optimizer
+            object.
+
+    References:
+        J. Stokes, J. Izaac, N. Killoran, and G. Carleo, *Quantum Natural
+        Gradient*, `arXiv:1909.02108 <https://arxiv.org/abs/1909.02108>`_.
+    """
+
+    def __init__(
+        self,
+        circuit: Circuit,
+        loss_fn,
+        loss_kwargs: dict | None = None,
+        initial_parameters: ArrayLike | None = None,
+        learning_rate: float = 0.01,
+        regularization: float = 1e-3,
+        callback: Callable[..., None] | None = None,
+        seed: int | None = None,
+        backend: Backend = None,
+    ):
+        del seed  # API compatibility; initialization comes from circuit parameters.
+
+        self.backend = _check_backend(backend)
+        self.qibo_backend = _BackendCastAdapter(self.backend)
+        self.circuit = circuit
+        self.learning_rate = learning_rate
+        self.regularization = regularization
+        self.callback = callback
+        self.n_calls_loss = 0
+        self.n_calls_gradient = 0
+        self.last_gradient = None
+        self.loss_kwargs = {} if loss_kwargs is None else dict(loss_kwargs)
+
+        if initial_parameters is None:
+            initial_parameters = circuit.get_parameters()
+        self.parameters = self.backend.cast(
+            np.asarray(
+                self.backend.to_numpy(initial_parameters), dtype=np.float64
+            ).reshape(-1),
+            dtype=self.backend.float64,
+        )
+        self.circuit.set_parameters(self.parameters)
+
+        if not isinstance(loss_fn, (str, Callable)):
+            raise_error(
+                TypeError,
+                "``loss_fn`` must be either the str ``exp_val`` or "
+                + f"``Callable``. Passed {type(loss_fn)}",
+            )
+        elif isinstance(loss_fn, str) and loss_fn != "exp_val":
+            raise_error(
+                ValueError,
+                f"If str, ``loss_fn`` can only be ``exp_val``. Passed {type(loss_fn)}.",
+            )
+
+        self.loss_fn = loss_fn
+        self.hamiltonian = None
+        if "hamiltonian" in self.loss_kwargs:
+            self.hamiltonian = self.loss_kwargs.get("hamiltonian", None)
+            if not (
+                isinstance(self.hamiltonian, self.backend.tensor_types)
+                or issparse(self.hamiltonian)
+            ):
+                raise_error(
+                    TypeError,
+                    f"For backend <{self.backend}>, ``hamiltonian`` must be scipy sparse matrix, "
+                    + f"or one of these: {self.backend.tensor_types}\n"
+                    + f"passed type: {type(self.hamiltonian)}!",
+                )
+            if issparse(self.hamiltonian):
+                if self.backend.platform is not None:
+                    self.hamiltonian = _scipy_sparse_to_backend_coo(
+                        self.hamiltonian, self.backend
+                    )
+            else:
+                if self.backend.platform is not None:
+                    self.hamiltonian = self.backend.coo_matrix(self.hamiltonian)
+                else:
+                    self.hamiltonian = self.backend.csr_matrix(self.hamiltonian)
+
+            self.loss_kwargs["hamiltonian"] = self.hamiltonian
+
+        if loss_fn == "exp_val":
+            if self.hamiltonian is None:
+                raise_error(
+                    ValueError,
+                    "For ``loss_fn='exp_val'``, you must pass the hamiltonian to ``loss_kwargs`` "
+                    + "via the dict item ``{'hamiltonian': hamiltonian}``",
+                )
+            self.loss_fn = _loss_func_expval
+            self.parameter_shift_hamiltonian = Hamiltonian(
+                self.circuit.nqubits,
+                self._hamiltonian_to_dense(),
+                backend=self.qibo_backend,
+            )
+            self.gradient_func = None
+        else:
+            backends_autodiff = ["jax", "tensorflow", "pytorch"]
+            if self.backend.platform not in backends_autodiff:
+                raise_error(
+                    TypeError,
+                    f"To use autodiff, must use one of the following backends: {backends_autodiff}",
+                )
+            self.parameter_shift_hamiltonian = None
+            self.gradient_func = self._gradient_func_internal
+
+        self.loss = self._loss_internal
+
+    def metric_tensor(self) -> ArrayLike:
+        """Compute Fubini-Study metric tensor for current circuit parameters."""
+
+        qfim = quantum_fisher_information_matrix(
+            self.circuit,
+            parameters=self.parameters,
+            backend=self.qibo_backend,
+        )
+        return self.backend.cast(
+            self.backend.real(qfim) / 4.0, dtype=self.backend.float64
+        )
+
+    def gradient(self) -> ArrayLike:
+        """Compute gradient of current loss wrt circuit parameters."""
+
+        if self.loss_fn == _loss_func_expval:
+            self.n_calls_gradient += 1
+            gradient = [
+                parameter_shift(
+                    self.circuit,
+                    self.parameter_shift_hamiltonian,
+                    parameter_index=i,
+                )
+                for i in range(len(self.parameters))
+            ]
+            return self.backend.cast(gradient, dtype=self.backend.float64)
+
+        return self.gradient_func()
+
+    def step(self):
+        """Perform one QNG update step."""
+
+        g = self.metric_tensor()
+        grad = self.gradient()
+        self.last_gradient = grad
+
+        g_np = np.asarray(self.backend.to_numpy(g), dtype=np.float64)
+        grad_np = np.asarray(self.backend.to_numpy(grad), dtype=np.float64).reshape(-1)
+        system = g_np + self.regularization * np.eye(len(grad_np), dtype=np.float64)
+        rhs = -self.learning_rate * grad_np
+
+        try:
+            dtheta = np.linalg.solve(system, rhs)
+        except np.linalg.LinAlgError:
+            try:
+                dtheta = np.linalg.lstsq(system, rhs, rcond=None)[0]
+            except np.linalg.LinAlgError:  # pragma: no cover
+                dtheta = np.linalg.pinv(system) @ rhs
+
+        self.parameters = self.backend.cast(
+            np.asarray(self.backend.to_numpy(self.parameters), dtype=np.float64)
+            + dtheta,
+            dtype=self.backend.float64,
+        )
+        self.circuit.set_parameters(self.parameters)
+
+        return self.loss(self.circuit, self.backend, **self.loss_kwargs)
+
+    def run_qng(
+        self, steps: int = 100, tolerance: float = 1e-8
+    ) -> Tuple[float, ArrayLike, ArrayLike]:
+        """Run QNG optimization loop.
+
+        Args:
+            steps (int, optional): Number of optimization iterations.
+                Defaults to :math:`100`.
+            tolerance (float, optional): Early-stop threshold for the Euclidean
+                norm of gradient. Defaults to :math:`10^{-8}`.
+
+        Returns:
+            Tuple[float, ArrayLike, ArrayLike]:
+                Final loss, loss history, and final optimized parameters.
+        """
+
+        losses = []
+        for iter_num in range(steps):
+            loss_value = self.step()
+            losses.append(loss_value)
+
+            if self.callback is not None:
+                self.callback(
+                    iter_num=iter_num + 1,
+                    loss=loss_value,
+                    parameters=self.parameters,
+                )
+
+            if self.backend.vector_norm(self.last_gradient) < tolerance:
+                break
+
+        final_loss = (
+            losses[-1]
+            if losses
+            else self.loss(self.circuit, self.backend, **self.loss_kwargs)
+        )
+        final_parameters = self.parameters
+        return (
+            self.backend.cast(final_loss, dtype=self.backend.float64),
+            self.backend.cast(losses, dtype=self.backend.float64),
+            self.backend.cast(final_parameters, dtype=final_parameters.dtype),
+        )
+
+    def __call__(
+        self, steps: int = 100, tolerance: float = 1e-8
+    ) -> Tuple[float, ArrayLike, ArrayLike]:
+        """Run QNG optimization loop."""
+
+        return self.run_qng(steps=steps, tolerance=tolerance)
+
+    def _loss_internal(self, circuit: Circuit, backend: Backend, **kwargs) -> float:
+        """Wrapper around loss function updating ``n_calls_loss``."""
+
+        self.n_calls_loss += 1
+        return self.loss_fn(circuit, backend, **kwargs)
+
+    def _gradient_func_internal(self) -> ArrayLike:
+        """Compute backend autodiff gradient for generic callable losses."""
+
+        self.n_calls_gradient += 1
+
+        platform = self.backend.platform
+        if platform == "jax":
+            circuit_orig = self.circuit.copy(deep=True)
+
+            def loss_fn(params):
+                self.circuit.set_parameters(params)
+                return self.loss(self.circuit, self.backend, **self.loss_kwargs)
+
+            params = self.backend.cast(
+                self.circuit.get_parameters(),
+                dtype=self.backend.float64,
+            )
+            grad = self.backend.jax.grad(loss_fn)(params)
+            self.circuit = circuit_orig.copy(deep=True)
+            return grad.reshape(-1)
+        if platform == "pytorch":
+            params = self.backend.cast(
+                self.circuit.get_parameters(), dtype=self.parameters.dtype
+            )
+            params.requires_grad = True
+            self.circuit.set_parameters(params)
+            loss = self.loss(self.circuit, self.backend, **self.loss_kwargs)
+            loss.backward()
+            return params.grad.reshape(-1)
+        if platform == "tensorflow":
+            params = self.backend.engine.Variable(
+                self.circuit.get_parameters(),
+                dtype=self.backend.float64,
+            )
+            with self.backend.engine.GradientTape() as tape:
+                self.circuit.set_parameters(params)
+                loss = self.loss(self.circuit, self.backend, **self.loss_kwargs)
+            grad = tape.gradient(loss, params)
+            return grad.reshape(-1)
+
+    def _hamiltonian_to_dense(self):
+        """Convert validated Hamiltonian storage to dense array for PSR."""
+
+        if issparse(self.hamiltonian):
+            return self.hamiltonian.toarray()
+
+        if self.backend.platform == "jax" and hasattr(self.hamiltonian, "todense"):
+            return np.asarray(self.hamiltonian.todense())
+
+        if self.backend.platform == "tensorflow" and isinstance(
+            self.hamiltonian, self.backend.engine.sparse.SparseTensor
+        ):
+            return self.backend.to_numpy(
+                self.backend.engine.sparse.to_dense(self.hamiltonian)
+            )
+
+        if self.backend.platform == "pytorch" and getattr(
+            self.hamiltonian, "is_sparse", False
+        ):
+            return self.hamiltonian.to_dense().cpu().numpy(force=True)
+
+        return np.asarray(self.backend.to_numpy(self.hamiltonian))
 
 
 class ExactGeodesicTransportCG:

--- a/src/qiboml/models/optimizers.py
+++ b/src/qiboml/models/optimizers.py
@@ -88,7 +88,6 @@ class QuantumNaturalGradient:
         del seed  # API compatibility; initialization comes from circuit parameters.
 
         self.backend = _check_backend(backend)
-        self.qibo_backend = _BackendCastAdapter(self.backend)
         self.circuit = circuit
         self.learning_rate = learning_rate
         self.regularization = regularization
@@ -114,7 +113,7 @@ class QuantumNaturalGradient:
                 "``loss_fn`` must be either the str ``exp_val`` or "
                 + f"``Callable``. Passed {type(loss_fn)}",
             )
-        elif isinstance(loss_fn, str) and loss_fn != "exp_val":
+        if isinstance(loss_fn, str) and loss_fn != "exp_val":
             raise_error(
                 ValueError,
                 f"If str, ``loss_fn`` can only be ``exp_val``. Passed {type(loss_fn)}.",
@@ -158,7 +157,7 @@ class QuantumNaturalGradient:
             self.parameter_shift_hamiltonian = Hamiltonian(
                 self.circuit.nqubits,
                 self._hamiltonian_to_dense(),
-                backend=self.qibo_backend,
+                backend=self.backend,
             )
             self.gradient_func = None
         else:
@@ -179,7 +178,7 @@ class QuantumNaturalGradient:
         qfim = quantum_fisher_information_matrix(
             self.circuit,
             parameters=self.parameters,
-            backend=self.qibo_backend,
+            backend=self.backend,
         )
         return self.backend.cast(
             self.backend.real(qfim) / 4.0, dtype=self.backend.float64

--- a/tests/test_models_optimizers.py
+++ b/tests/test_models_optimizers.py
@@ -319,8 +319,7 @@ def _build_ry_cz_ansatz(nqubits):
 
 
 @pytest.mark.parametrize("nqubits", [2, 3])
-def test_quantum_natural_gradient_vqe(autodiff_backend, nqubits):
-    backend = autodiff_backend
+def test_quantum_natural_gradient_vqe(backend, nqubits):
     circuit = _build_ry_cz_ansatz(nqubits)
     hamiltonian = hamiltonians.Z(nqubits, backend=backend).matrix
     initial_parameters = backend.cast(
@@ -351,8 +350,7 @@ def test_quantum_natural_gradient_vqe(autodiff_backend, nqubits):
     assert backend.abs(final_loss + nqubits) < 1e-5
 
 
-def test_quantum_natural_gradient_metric_tensor(autodiff_backend):
-    backend = autodiff_backend
+def test_quantum_natural_gradient_metric_tensor(backend):
     circuit = _build_ry_cz_ansatz(3)
     parameters = backend.cast(
         [0.17, -0.31, 0.29, 0.12, -0.44, 0.08], dtype=backend.float64
@@ -369,13 +367,10 @@ def test_quantum_natural_gradient_metric_tensor(autodiff_backend):
     qfim = quantum_fisher_information_matrix(
         circuit,
         parameters=parameters,
-        backend=optimizer.qibo_backend,
+        backend=backend,
     )
-    expected = backend.cast(backend.real(qfim) / 4.0, dtype=backend.float64)
-    metric_transpose = backend.cast(
-        np.transpose(backend.to_numpy(metric)),
-        dtype=backend.float64,
-    )
+    expected = backend.real(qfim) / 4.0
+    metric_transpose = backend.transpose(metric)
 
     backend.assert_allclose(metric, expected, atol=1e-7)
     backend.assert_allclose(metric, metric_transpose, atol=1e-7)
@@ -388,7 +383,7 @@ def test_quantum_natural_gradient_callable_loss(autodiff_backend):
 
     def callable_loss(circuit, backend):
         state = backend.execute_circuit(circuit).state()
-        return backend.real(state[0] * backend.conj(state[0]))
+        return backend.real(state * backend.conj(state))
 
     optimizer = QuantumNaturalGradient(
         circuit=circuit,
@@ -411,7 +406,7 @@ def test_quantum_natural_gradient_callable_loss_errors():
 
     def callable_loss(circuit, backend):
         state = backend.execute_circuit(circuit).state()
-        return backend.real(state[0] * backend.conj(state[0]))
+        return backend.real(state * backend.conj(state))
 
     with pytest.raises(TypeError):
         _ = QuantumNaturalGradient(
@@ -423,7 +418,7 @@ def test_quantum_natural_gradient_callable_loss_errors():
 
 def test_quantum_natural_gradient_errors(autodiff_backend):
     backend = autodiff_backend
-    circuit = _build_ry_cz_ansatz(2)
+def test_quantum_natural_gradient_errors(backend):
 
     with pytest.raises(TypeError):
         _ = QuantumNaturalGradient(
@@ -459,9 +454,8 @@ def test_quantum_natural_gradient_errors(autodiff_backend):
 
 
 def test_quantum_natural_gradient_sparse_hamiltonian_callback_and_tolerance(
-    autodiff_backend,
+    backend,
 ):
-    backend = autodiff_backend
     circuit = _build_ry_cz_ansatz(2)
     hamiltonian = csr_matrix(hamiltonians.Z(2, backend=backend).matrix)
     callback_calls = []
@@ -486,8 +480,7 @@ def test_quantum_natural_gradient_sparse_hamiltonian_callback_and_tolerance(
     assert np.isfinite(np.asarray(backend.to_numpy(final_loss), dtype=np.float64)).all()
 
 
-def test_quantum_natural_gradient_linear_solve_fallback(autodiff_backend, monkeypatch):
-    backend = autodiff_backend
+def test_quantum_natural_gradient_linear_solve_fallback(backend):
     circuit = _build_ry_cz_ansatz(2)
     optimizer = QuantumNaturalGradient(
         circuit=circuit,

--- a/tests/test_models_optimizers.py
+++ b/tests/test_models_optimizers.py
@@ -7,38 +7,53 @@ from qibo.models.encodings import _generate_rbs_angles
 from qibo.quantum_info import quantum_fisher_information_matrix, random_statevector
 from scipy.sparse import csr_matrix
 from scipy.special import comb
+from types import MethodType
 
 from qiboml.models.optimizers import ExactGeodesicTransportCG, QuantumNaturalGradient
 
 
-def _get_autodiff_backend(name):
-    if name == "jax":
-        from qiboml.backends.jax import JaxBackend
+def _qibo_qfim(circuit, parameters, backend):
+    original_cast = backend.cast
+    original_jacobian = getattr(backend, "jacobian", None)
 
-        return JaxBackend()
-    if name == "tensorflow":
-        from qiboml.backends.tensorflow import TensorflowBackend
+    def cast_with_numpy_dtypes(bound_backend, array, dtype=None, copy=False, **kwargs):
+        if dtype is not None:
+            try:
+                dtype = getattr(bound_backend, np.dtype(dtype).name)
+            except (AttributeError, TypeError):
+                pass
+        return original_cast(array, dtype=dtype, copy=copy, **kwargs)
 
-        return TensorflowBackend()
-    if name == "pytorch":
-        from qiboml.backends.pytorch import PyTorchBackend
+    def jax_jacobian(bound_backend, copied_circuit, params, initial_state=None, return_complex=True):
+        copied = copied_circuit.copy(deep=True)
 
-        return PyTorchBackend()
-    raise RuntimeError(f"Unknown backend {name}.")
+        def state_components(local_params):
+            copied.set_parameters(local_params)
+            state = bound_backend.execute_circuit(
+                copied, initial_state=initial_state
+            ).state()
+            if return_complex:
+                return bound_backend.real(state), bound_backend.imag(state)
+            return bound_backend.real(state)
 
+        return bound_backend.jax.jacobian(state_components)(params)
 
-AUTODIFF_BACKENDS = []
-for _backend_name in ("tensorflow", "pytorch", "jax"):
+    backend.cast = MethodType(cast_with_numpy_dtypes, backend)
+    if backend.platform == "jax":
+        backend.jacobian = MethodType(jax_jacobian, backend)
+
     try:
-        _ = _get_autodiff_backend(_backend_name)
-        AUTODIFF_BACKENDS.append(_backend_name)
-    except (ModuleNotFoundError, ImportError):
-        pass
-
-
-@pytest.fixture(params=AUTODIFF_BACKENDS)
-def autodiff_backend(request):
-    yield _get_autodiff_backend(request.param)
+        return quantum_fisher_information_matrix(
+            circuit,
+            parameters=parameters,
+            backend=backend,
+        )
+    finally:
+        backend.cast = original_cast
+        if backend.platform == "jax":
+            backend.jacobian = original_jacobian
+        elif original_jacobian is not None:
+            backend.jacobian = original_jacobian
 
 
 def test_egt_cg_errors(backend):
@@ -151,12 +166,6 @@ def test_egt_cg(
     type_loss_grad,
     initial_parameters,
 ):
-    if backend.platform in ["jax", "tensorflow"] and nqubits != 4:
-        pytest.skip(
-            "Tests too slow with Jax and TF, will test only small size."
-            + " Will test all sizes with torch."
-        )
-
     hamiltonian, true_gs_energy = _get_xxz_hamiltonian(
         nqubits, hamiltonian_type, backend
     )
@@ -364,26 +373,28 @@ def test_quantum_natural_gradient_metric_tensor(backend):
         backend=backend,
     )
     metric = optimizer.metric_tensor()
-    qfim = quantum_fisher_information_matrix(
-        circuit,
-        parameters=parameters,
-        backend=backend,
+    expected = backend.real(_qibo_qfim(circuit, parameters, backend)) / 4.0
+    metric_np = np.asarray(backend.to_numpy(metric), dtype=np.float64)
+    metric_transpose = metric_np.T
+
+    np.testing.assert_allclose(
+        metric_np,
+        np.asarray(backend.to_numpy(expected), dtype=np.float64),
+        atol=1e-7,
     )
-    expected = backend.real(qfim) / 4.0
-    metric_transpose = backend.transpose(metric)
-
-    backend.assert_allclose(metric, expected, atol=1e-7)
-    backend.assert_allclose(metric, metric_transpose, atol=1e-7)
+    np.testing.assert_allclose(metric_np, metric_transpose, atol=1e-7)
 
 
-def test_quantum_natural_gradient_callable_loss(autodiff_backend):
-    backend = autodiff_backend
+def test_quantum_natural_gradient_callable_loss(backend):
     circuit = _build_ry_cz_ansatz(2)
     initial_parameters = backend.cast([0.2, -0.1, 0.3, 0.4], dtype=backend.float64)
+    circuit.set_parameters(initial_parameters)
 
     def callable_loss(circuit, backend):
         state = backend.execute_circuit(circuit).state()
-        return backend.real(state * backend.conj(state))
+        return 1.0 - backend.real(backend.conj(state[0]) * state[0])
+
+    initial_loss = np.asarray(backend.to_numpy(callable_loss(circuit, backend))).item()
 
     optimizer = QuantumNaturalGradient(
         circuit=circuit,
@@ -394,10 +405,18 @@ def test_quantum_natural_gradient_callable_loss(autodiff_backend):
         backend=backend,
     )
     loss = optimizer.step()
+    circuit_parameters = backend.cast(
+        np.asarray(
+            backend.to_numpy(circuit.get_parameters()), dtype=np.float64
+        ).reshape(-1),
+        dtype=backend.float64,
+    )
 
+    assert optimizer.circuit is circuit
     assert optimizer.n_calls_gradient == 1
     assert optimizer.n_calls_loss >= 1
-    assert np.isfinite(np.asarray(backend.to_numpy(loss), dtype=np.float64)).all()
+    backend.assert_allclose(circuit_parameters, optimizer.parameters, atol=1e-7)
+    assert np.asarray(backend.to_numpy(loss)).item() <= initial_loss
 
 
 def test_quantum_natural_gradient_callable_loss_errors():
@@ -416,9 +435,8 @@ def test_quantum_natural_gradient_callable_loss_errors():
         )
 
 
-def test_quantum_natural_gradient_errors(autodiff_backend):
-    backend = autodiff_backend
 def test_quantum_natural_gradient_errors(backend):
+    circuit = _build_ry_cz_ansatz(2)
 
     with pytest.raises(TypeError):
         _ = QuantumNaturalGradient(
@@ -477,23 +495,4 @@ def test_quantum_natural_gradient_sparse_hamiltonian_callback_and_tolerance(
 
     assert len(losses) == 1
     assert len(callback_calls) == 1
-    assert np.isfinite(np.asarray(backend.to_numpy(final_loss), dtype=np.float64)).all()
-
-
-def test_quantum_natural_gradient_linear_solve_fallback(backend):
-    circuit = _build_ry_cz_ansatz(2)
-    optimizer = QuantumNaturalGradient(
-        circuit=circuit,
-        loss_fn="exp_val",
-        loss_kwargs={"hamiltonian": hamiltonians.Z(2, backend=backend).matrix},
-        initial_parameters=backend.cast([0.2, -0.1, 0.3, 0.4], dtype=backend.float64),
-        backend=backend,
-    )
-
-    def fail_solve(*args, **kwargs):
-        raise np.linalg.LinAlgError()
-
-    monkeypatch.setattr(np.linalg, "solve", fail_solve)
-    loss = optimizer.step()
-
-    assert np.isfinite(np.asarray(backend.to_numpy(loss), dtype=np.float64)).all()
+    backend.assert_allclose(final_loss, losses[0], atol=1e-7)

--- a/tests/test_models_optimizers.py
+++ b/tests/test_models_optimizers.py
@@ -1,3 +1,5 @@
+from types import MethodType
+
 import numpy as np
 import pytest
 import scipy
@@ -7,7 +9,6 @@ from qibo.models.encodings import _generate_rbs_angles
 from qibo.quantum_info import quantum_fisher_information_matrix, random_statevector
 from scipy.sparse import csr_matrix
 from scipy.special import comb
-from types import MethodType
 
 from qiboml.models.optimizers import ExactGeodesicTransportCG, QuantumNaturalGradient
 
@@ -24,7 +25,9 @@ def _qibo_qfim(circuit, parameters, backend):
                 pass
         return original_cast(array, dtype=dtype, copy=copy, **kwargs)
 
-    def jax_jacobian(bound_backend, copied_circuit, params, initial_state=None, return_complex=True):
+    def jax_jacobian(
+        bound_backend, copied_circuit, params, initial_state=None, return_complex=True
+    ):
         copied = copied_circuit.copy(deep=True)
 
         def state_components(local_params):
@@ -185,17 +188,6 @@ def test_egt_cg(
             backend=backend,
         )
 
-    def make_callback(print_every):
-        def callback(
-            iter_num,
-            loss,
-            **kwargs,
-        ):
-            if iter_num % print_every == 0:
-                print(f"Iter {iter_num}: loss = {loss:.6f}")
-
-        return callback
-
     optimizer = ExactGeodesicTransportCG(
         nqubits=nqubits,
         weight=int(nqubits / 2),
@@ -206,7 +198,7 @@ def test_egt_cg(
         c2=0.999,
         backtrack_rate=0.5,
         backtrack_multiplier=1.5,
-        callback=make_callback(1000),
+        callback=None,
         seed=13,
         backend=backend,
     )
@@ -267,17 +259,6 @@ def test_egt_cg_numpy(
             backend=backend,
         )
 
-    def make_callback(print_every):
-        def callback(
-            iter_num,
-            loss,
-            **kwargs,
-        ):
-            if iter_num % print_every == 0:
-                print(f"Iter {iter_num}: loss = {loss:.6f}")
-
-        return callback
-
     optimizer = ExactGeodesicTransportCG(
         nqubits=nqubits,
         weight=int(nqubits / 2),
@@ -288,7 +269,7 @@ def test_egt_cg_numpy(
         c2=0.999,
         backtrack_rate=0.5,
         backtrack_multiplier=1.5,
-        callback=make_callback(1000),
+        callback=None,
         seed=13,
         backend=backend,
     )
@@ -425,7 +406,7 @@ def test_quantum_natural_gradient_callable_loss_errors():
 
     def callable_loss(circuit, backend):
         state = backend.execute_circuit(circuit).state()
-        return backend.real(state * backend.conj(state))
+        return 1.0 - backend.real(backend.conj(state[0]) * state[0])
 
     with pytest.raises(TypeError):
         _ = QuantumNaturalGradient(
@@ -495,4 +476,10 @@ def test_quantum_natural_gradient_sparse_hamiltonian_callback_and_tolerance(
 
     assert len(losses) == 1
     assert len(callback_calls) == 1
+    assert callback_calls[0]["iter_num"] == 1
+    backend.assert_allclose(callback_calls[0]["loss"], losses[0], atol=1e-7)
+    backend.assert_allclose(
+        callback_calls[0]["parameters"], optimizer.parameters, atol=1e-7
+    )
+    assert optimizer.n_calls_loss == 1
     backend.assert_allclose(final_loss, losses[0], atol=1e-7)

--- a/tests/test_models_optimizers.py
+++ b/tests/test_models_optimizers.py
@@ -1,13 +1,44 @@
+import numpy as np
 import pytest
 import scipy
-from qibo import hamiltonians
+from qibo import Circuit, gates, hamiltonians
 from qibo.backends import NumpyBackend
 from qibo.models.encodings import _generate_rbs_angles
-from qibo.quantum_info import random_statevector
+from qibo.quantum_info import quantum_fisher_information_matrix, random_statevector
 from scipy.sparse import csr_matrix
 from scipy.special import comb
 
-from qiboml.models.optimizers import ExactGeodesicTransportCG
+from qiboml.models.optimizers import ExactGeodesicTransportCG, QuantumNaturalGradient
+
+
+def _get_autodiff_backend(name):
+    if name == "jax":
+        from qiboml.backends.jax import JaxBackend
+
+        return JaxBackend()
+    if name == "tensorflow":
+        from qiboml.backends.tensorflow import TensorflowBackend
+
+        return TensorflowBackend()
+    if name == "pytorch":
+        from qiboml.backends.pytorch import PyTorchBackend
+
+        return PyTorchBackend()
+    raise RuntimeError(f"Unknown backend {name}.")
+
+
+AUTODIFF_BACKENDS = []
+for _backend_name in ("tensorflow", "pytorch", "jax"):
+    try:
+        _ = _get_autodiff_backend(_backend_name)
+        AUTODIFF_BACKENDS.append(_backend_name)
+    except (ModuleNotFoundError, ImportError):
+        pass
+
+
+@pytest.fixture(params=AUTODIFF_BACKENDS)
+def autodiff_backend(request):
+    yield _get_autodiff_backend(request.param)
 
 
 def test_egt_cg_errors(backend):
@@ -274,3 +305,202 @@ def _get_xxz_hamiltonian(nqubits, hamiltonian_type, backend):
         true_gs_energy = backend.real(backend.cast(eigenvalues[0]))
 
     return hamiltonian, true_gs_energy
+
+
+def _build_ry_cz_ansatz(nqubits):
+    circuit = Circuit(nqubits)
+    for qubit in range(nqubits):
+        circuit.add(gates.RY(qubit, theta=0.0))
+    for qubit in range(nqubits - 1):
+        circuit.add(gates.CZ(qubit, qubit + 1))
+    for qubit in range(nqubits):
+        circuit.add(gates.RY(qubit, theta=0.0))
+    return circuit
+
+
+@pytest.mark.parametrize("nqubits", [2, 3])
+def test_quantum_natural_gradient_vqe(autodiff_backend, nqubits):
+    backend = autodiff_backend
+    circuit = _build_ry_cz_ansatz(nqubits)
+    hamiltonian = hamiltonians.Z(nqubits, backend=backend).matrix
+    initial_parameters = backend.cast(
+        np.linspace(0.1, 0.6, len(circuit.get_parameters())),
+        dtype=backend.float64,
+    )
+
+    optimizer = QuantumNaturalGradient(
+        circuit=circuit,
+        loss_fn="exp_val",
+        loss_kwargs={"hamiltonian": hamiltonian},
+        initial_parameters=initial_parameters,
+        learning_rate=0.2,
+        regularization=1e-3,
+        backend=backend,
+    )
+    final_loss, losses, final_parameters = optimizer(steps=40, tolerance=1e-10)
+    circuit_parameters = backend.cast(
+        np.asarray(
+            backend.to_numpy(circuit.get_parameters()), dtype=np.float64
+        ).reshape(-1),
+        dtype=backend.float64,
+    )
+
+    assert optimizer.n_calls_loss >= len(losses)
+    assert optimizer.n_calls_gradient >= 1
+    backend.assert_allclose(final_parameters, circuit_parameters, atol=1e-7)
+    assert backend.abs(final_loss + nqubits) < 1e-5
+
+
+def test_quantum_natural_gradient_metric_tensor(autodiff_backend):
+    backend = autodiff_backend
+    circuit = _build_ry_cz_ansatz(3)
+    parameters = backend.cast(
+        [0.17, -0.31, 0.29, 0.12, -0.44, 0.08], dtype=backend.float64
+    )
+    circuit.set_parameters(parameters)
+
+    optimizer = QuantumNaturalGradient(
+        circuit=circuit,
+        loss_fn="exp_val",
+        loss_kwargs={"hamiltonian": hamiltonians.Z(3, backend=backend).matrix},
+        backend=backend,
+    )
+    metric = optimizer.metric_tensor()
+    qfim = quantum_fisher_information_matrix(
+        circuit,
+        parameters=parameters,
+        backend=optimizer.qibo_backend,
+    )
+    expected = backend.cast(backend.real(qfim) / 4.0, dtype=backend.float64)
+    metric_transpose = backend.cast(
+        np.transpose(backend.to_numpy(metric)),
+        dtype=backend.float64,
+    )
+
+    backend.assert_allclose(metric, expected, atol=1e-7)
+    backend.assert_allclose(metric, metric_transpose, atol=1e-7)
+
+
+def test_quantum_natural_gradient_callable_loss(autodiff_backend):
+    backend = autodiff_backend
+    circuit = _build_ry_cz_ansatz(2)
+    initial_parameters = backend.cast([0.2, -0.1, 0.3, 0.4], dtype=backend.float64)
+
+    def callable_loss(circuit, backend):
+        state = backend.execute_circuit(circuit).state()
+        return backend.real(state[0] * backend.conj(state[0]))
+
+    optimizer = QuantumNaturalGradient(
+        circuit=circuit,
+        loss_fn=callable_loss,
+        initial_parameters=initial_parameters,
+        learning_rate=0.05,
+        regularization=1e-3,
+        backend=backend,
+    )
+    loss = optimizer.step()
+
+    assert optimizer.n_calls_gradient == 1
+    assert optimizer.n_calls_loss >= 1
+    assert np.isfinite(np.asarray(backend.to_numpy(loss), dtype=np.float64)).all()
+
+
+def test_quantum_natural_gradient_callable_loss_errors():
+    backend = NumpyBackend()
+    circuit = _build_ry_cz_ansatz(2)
+
+    def callable_loss(circuit, backend):
+        state = backend.execute_circuit(circuit).state()
+        return backend.real(state[0] * backend.conj(state[0]))
+
+    with pytest.raises(TypeError):
+        _ = QuantumNaturalGradient(
+            circuit=circuit,
+            loss_fn=callable_loss,
+            backend=backend,
+        )
+
+
+def test_quantum_natural_gradient_errors(autodiff_backend):
+    backend = autodiff_backend
+    circuit = _build_ry_cz_ansatz(2)
+
+    with pytest.raises(TypeError):
+        _ = QuantumNaturalGradient(
+            circuit=circuit,
+            loss_fn=13,
+            loss_kwargs={"hamiltonian": hamiltonians.Z(2, backend=backend).matrix},
+            backend=backend,
+        )
+
+    with pytest.raises(ValueError):
+        _ = QuantumNaturalGradient(
+            circuit=circuit,
+            loss_fn="expval",
+            loss_kwargs={"hamiltonian": hamiltonians.Z(2, backend=backend).matrix},
+            backend=backend,
+        )
+
+    with pytest.raises(TypeError):
+        _ = QuantumNaturalGradient(
+            circuit=circuit,
+            loss_fn="exp_val",
+            loss_kwargs={"hamiltonian": [("bad", "hamiltonian")]},
+            backend=backend,
+        )
+
+    with pytest.raises(ValueError):
+        _ = QuantumNaturalGradient(
+            circuit=circuit,
+            loss_fn="exp_val",
+            loss_kwargs={},
+            backend=backend,
+        )
+
+
+def test_quantum_natural_gradient_sparse_hamiltonian_callback_and_tolerance(
+    autodiff_backend,
+):
+    backend = autodiff_backend
+    circuit = _build_ry_cz_ansatz(2)
+    hamiltonian = csr_matrix(hamiltonians.Z(2, backend=backend).matrix)
+    callback_calls = []
+
+    optimizer = QuantumNaturalGradient(
+        circuit=circuit,
+        loss_fn="exp_val",
+        loss_kwargs={"hamiltonian": hamiltonian},
+        initial_parameters=backend.cast([0.2, -0.1, 0.3, 0.4], dtype=backend.float64),
+        callback=lambda **kwargs: callback_calls.append(kwargs),
+        backend=backend,
+    )
+    optimizer.gradient = lambda: backend.cast(
+        np.zeros(len(optimizer.parameters)),
+        dtype=backend.float64,
+    )
+
+    final_loss, losses, _ = optimizer.run_qng(steps=5, tolerance=1e-12)
+
+    assert len(losses) == 1
+    assert len(callback_calls) == 1
+    assert np.isfinite(np.asarray(backend.to_numpy(final_loss), dtype=np.float64)).all()
+
+
+def test_quantum_natural_gradient_linear_solve_fallback(autodiff_backend, monkeypatch):
+    backend = autodiff_backend
+    circuit = _build_ry_cz_ansatz(2)
+    optimizer = QuantumNaturalGradient(
+        circuit=circuit,
+        loss_fn="exp_val",
+        loss_kwargs={"hamiltonian": hamiltonians.Z(2, backend=backend).matrix},
+        initial_parameters=backend.cast([0.2, -0.1, 0.3, 0.4], dtype=backend.float64),
+        backend=backend,
+    )
+
+    def fail_solve(*args, **kwargs):
+        raise np.linalg.LinAlgError()
+
+    monkeypatch.setattr(np.linalg, "solve", fail_solve)
+    loss = optimizer.step()
+
+    assert np.isfinite(np.asarray(backend.to_numpy(loss), dtype=np.float64)).all()


### PR DESCRIPTION
## Summary
For issue #207 
Add a new `QuantumNaturalGradient` optimizer to `qiboml.models.optimizers` for generic parametrized circuits.

This implementation:
- follows the existing optimizer API style used by `ExactGeodesicTransportCG`
- supports both `"exp_val"` and generic callable losses
- computes the metric tensor using Qibo's QFIM implementation
- uses the Fubini-Study metric by dividing QFIM by 4
- applies a regularized linear solve for the natural-gradient update

## Changes

- added `QuantumNaturalGradient` in `src/qiboml/models/optimizers.py`
- added QNG docs to:
  - `doc/source/advanced/optimizers.rst`
  - `doc/source/api-reference/qiboml.models.rst`
- added tests in `tests/test_models_optimizers.py` covering:
  - VQE convergence on small RY+CZ ansatze
  - metric tensor correctness and symmetry
  - callable loss support on autodiff backends
  - expected failure on non-autodiff backend
  - invalid `loss_fn` / invalid Hamiltonian / missing Hamiltonian
  - sparse Hamiltonian path
  - callback + early stopping behavior
  - linear solve fallback path

## AI Disclosure
Codex 5.4 was utilized to help with programming, testing and documenting the added code